### PR TITLE
Use Pysam for sequence generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 install:
   - conda create --yes -n env_name python=$PYTHON_VERSION pip numpy scipy nose flake8 h5py
   - source activate env_name
-  - conda install --yes -c bioconda "VSEARCH>=2.0.3" MAFFT=7.310 SortMeRNA=2.0
+  - conda install --yes -c bioconda "VSEARCH>=2.0.3" MAFFT=7.310 SortMeRNA=2.0 pysam
   - pip install coveralls
   - pip install --process-dependency-links .
 script:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ source activate deblurenv
 
 Install Deblur dependencies and Deblur itself:
 ```
-conda install -c bioconda -c biocore VSEARCH MAFFT=7.310 biom-format SortMeRNA==2.0 deblur
+conda install -c bioconda -c biocore VSEARCH MAFFT=7.310 biom-format SortMeRNA==2.0 pysam deblur
 ```
 
 N.B. Some dependencies are version restricted at the moment but for different reasons. SortMeRNA 2.1 has a different output format which Deblur is not compatible with yet. A review of the changelog did not reveal any remarkable notes (e.g., bugs) about the reasons for the differences. In testing, the differences affected <0.1% of the sOTUs. As a precaution, we are advising the use of these specific versions for consistency with the manuscript.

--- a/deblur/test/test_workflow.py
+++ b/deblur/test/test_workflow.py
@@ -32,7 +32,6 @@ from deblur.workflow import (dereplicate_seqs,
                              start_log, sequence_generator,
                              sample_id_from_read_id,
                              remove_artifacts_from_biom_table,
-                             _get_fastq_variant,
                              filter_minreads_samples_from_table,
                              fasta_from_biom)
 from deblur.deblurring import get_default_error_profile
@@ -77,18 +76,6 @@ class workflowTests(TestCase):
         for f in self.files_to_remove:
             remove(f)
         rmtree(self.working_dir)
-
-    def test_get_fastq_variant(self):
-        exp = 'illumina1.8'
-        obs = _get_fastq_variant(self.seqs_fq_fp)
-        self.assertEqual(obs, exp)
-
-        exp = 'illumina1.3'
-        obs = _get_fastq_variant(self.seqs_fq_illumina13_fp)
-        self.assertEqual(obs, exp)
-
-        with self.assertRaises(ValueError):
-            _get_fastq_variant(self.seqs_fq_bad_fp)
 
     def test_sequence_generator_fasta(self):
         exp_len = 135

--- a/deblur/test/test_workflow.py
+++ b/deblur/test/test_workflow.py
@@ -935,7 +935,7 @@ class workflowTests(TestCase):
                 for seq in seqs_fasta[sample]:
                     seqs_f.write(">%s\n%s\n" % seq)
         output_dir = mkdtemp()
-        split_sequence_file_on_sample_ids_to_files(seqs=seqs_fp,
+        split_sequence_file_on_sample_ids_to_files(seqs_fp=seqs_fp,
                                                    outdir=output_dir)
         seqs_act = self.get_seqs_act_split_sequence_on_sample_ids(
             output_dir=output_dir)

--- a/deblur/test/utils.py
+++ b/deblur/test/utils.py
@@ -1,0 +1,16 @@
+from tempfile import NamedTemporaryFile
+
+
+def make_tempfile(contents, suffix):
+    """Returns a NamedTemporaryFile with text contents
+
+    Parameters
+    ----------
+    contents: string
+        The text to be written to the new temporary file
+    suffix: string
+        The suffix of the file path (e.g. ".fasta")
+    """
+    with NamedTemporaryFile(mode='wt', suffix=suffix, delete=False) as f:
+        f.file.write(contents)
+    return f

--- a/deblur/workflow.py
+++ b/deblur/workflow.py
@@ -32,25 +32,6 @@ sniff_fasta = skbio.io.io_registry.get_sniffer('fasta')
 sniff_fastq = skbio.io.io_registry.get_sniffer('fastq')
 
 
-def _get_fastq_variant(input_fp):
-    # http://scikit-bio.org/docs/latest/generated/skbio.io.format.fastq.html#format-parameters
-    variant = None
-    variants = ['illumina1.8', 'illumina1.3', 'solexa', 'sanger']
-    for v in variants:
-        try:
-            next(skbio.read(input_fp, format='fastq', variant=v))
-        except:
-            continue
-        else:
-            variant = v
-            break
-
-    if variant is None:
-        raise ValueError("Unknown variant, unable to interpret PHRED")
-
-    return variant
-
-
 def sequence_generator(input_fp):
     """Yield (id, sequence) from an input file
 

--- a/deblur/workflow.py
+++ b/deblur/workflow.py
@@ -17,9 +17,9 @@ import numpy as np
 import subprocess
 import time
 import warnings
-import io
 import os
 
+import pysam
 import skbio
 from biom.table import Table
 from biom.util import biom_open
@@ -65,11 +65,6 @@ def sequence_generator(input_fp):
     The use of this method is a stopgap to replicate the existing `parse_fasta`
     functionality while at the same time allowing for fastq support.
 
-    Raises
-    ------
-    skbio.io.FormatIdentificationWarning
-        If the format of the input file cannot be determined.
-
     Returns
     -------
     (str, str)
@@ -77,27 +72,16 @@ def sequence_generator(input_fp):
 
     """
     logger = logging.getLogger(__name__)
-    kw = {}
-    if sniff_fasta(input_fp)[0]:
-        format = 'fasta'
-    elif sniff_fastq(input_fp)[0]:
-        format = 'fastq'
-
-        kw['variant'] = _get_fastq_variant(input_fp)
-    else:
-        # usually happens when the fasta file is empty
-        # so need to return no sequences (and warn)
+    if not (sniff_fasta(input_fp)[0] or sniff_fastq(input_fp)[0]):
+        # usually happens when the FASTA/Q file is empty so need to return no
+        # sequences (and warn)
         msg = "input file %s does not appear to be FASTA or FASTQ" % input_fp
         logger.warn(msg)
         warnings.warn(msg, UserWarning)
         return
 
-    # some of the test code is using file paths, some is using StringIO.
-    if isinstance(input_fp, io.TextIOBase):
-        input_fp.seek(0)
-
-    for record in skbio.read(input_fp, format=format, **kw):
-        yield (record.metadata['id'], str(record))
+    for record in pysam.FastxFile(input_fp):
+        yield record.name, record.sequence
 
 
 def trim_seqs(input_seqs, trim_len, left_trim_len):
@@ -593,24 +577,23 @@ def sample_id_from_read_id(readid):
     return sampleid
 
 
-def split_sequence_file_on_sample_ids_to_files(seqs,
-                                               outdir):
+def split_sequence_file_on_sample_ids_to_files(seqs_fp, outdir):
     """Split FASTA file on sample IDs.
 
     Parameters
     ----------
-    seqs: file handler
-        file handler to demultiplexed FASTA file
+    seqs_fp: file path
+        path to demultiplexed FASTA file
     outdir: string
         dirpath to output split FASTA files
     """
     logger = logging.getLogger(__name__)
     logger.info('split_sequence_file_on_sample_ids_to_files'
-                ' for file %s into dir %s' % (seqs, outdir))
+                ' for file %s into dir %s' % (seqs_fp, outdir))
 
     outputs = {}
 
-    for bits in sequence_generator(seqs):
+    for bits in sequence_generator(seqs_fp):
         sample = sample_id_from_read_id(bits[0])
 
         if sample not in outputs:

--- a/scripts/deblur
+++ b/scripts/deblur
@@ -591,10 +591,7 @@ def workflow(seqs_fp, output_dir, pos_ref_fp, pos_ref_db_fp,
                         'output %s' % (seqs_fp, out_dir_split))
             mkdir(out_dir_split)
             created_split_dir = out_dir_split
-            with open(seqs_fp, 'U') as seqs_f:
-                split_sequence_file_on_sample_ids_to_files(
-                    seqs_f,
-                    out_dir_split)
+            split_sequence_file_on_sample_ids_to_files(seqs_fp, out_dir_split)
 
         patterns = ['*.fast[aq]', '*.fast[aq].gz', '*.fna', '*.fq', '*.fna.gz',
                     '*.fq.gz']


### PR DESCRIPTION
Using [Pysam](https://github.com/pysam-developers/pysam) (which wraps [htslib](http://www.htslib.org/)) speeds up the sequence trimming step by a good amount (~50x). This changeset switches from using `skbio.read()` to using `pysam.FastxFile()` and makes a few other changes to accommodate the `FastxFile()` requirement that the file be passed as a path (or stdin), not a Python file-like object.

As an example of the speedup, processing a ~50k FASTA file took 65s with `skbio.read()` and 1.4.s with `pysam.FastxFile()`.